### PR TITLE
Two changes to tink.tcp.Connection

### DIFF
--- a/src/tink/tcp/Connection.hx
+++ b/src/tink/tcp/Connection.hx
@@ -130,9 +130,9 @@ private class SocketInput extends haxe.io.Input {
     this.sockets = [s];
     
   function select() {
-	  #if concurrent
+    #if concurrent
     var selectTime = counter / 10000;
-	  #else
+    #else
     var selectTime = counter / 50000;
     #end
 
@@ -180,9 +180,9 @@ private class SocketOutput extends haxe.io.Output {
     this.sockets = [s];
     
   function select() {
-	  #if concurrent
+    #if concurrent
     var selectTime = counter / 10000;
-	  #else
+    #else
     var selectTime = counter / 50000;
     #end
     return  

--- a/src/tink/tcp/Connection.hx
+++ b/src/tink/tcp/Connection.hx
@@ -142,7 +142,7 @@ private class SocketInput extends haxe.io.Input {
           sockets;
         }
         #else
-          Socket.select(sockets, null, null, selectTime).read;
+          Socket.select(sockets, [], [], selectTime).read;
         #end
   }
     
@@ -187,7 +187,7 @@ private class SocketOutput extends haxe.io.Output {
           sockets;
         }
         #else
-          Socket.select(null, sockets, null, selectTime).write;
+          Socket.select([], sockets, [], selectTime).write;
         #end
   }
   

--- a/src/tink/tcp/Connection.hx
+++ b/src/tink/tcp/Connection.hx
@@ -130,8 +130,12 @@ private class SocketInput extends haxe.io.Input {
     this.sockets = [s];
     
   function select() {
+	  #if concurrent
     var selectTime = counter / 10000;
-    
+	  #else
+    var selectTime = counter / 50000;
+    #end
+
     return  
       if (counter <= 10)
         sockets;
@@ -176,7 +180,11 @@ private class SocketOutput extends haxe.io.Output {
     this.sockets = [s];
     
   function select() {
+	  #if concurrent
     var selectTime = counter / 10000;
+	  #else
+    var selectTime = counter / 50000;
+    #end
     return  
       if (counter <= 10)
         sockets;


### PR DESCRIPTION
First, Socket.select wants empty arrays instead of null otherwise it errors.

Second, I get better cpp performance when handling multiple sockets in non concurrent mode if I decrease the selectTimeout.  A socket that has no data will pause runloop execution up to selectTimeout seconds.
