### PR TITLE
Secure connection

### DIFF
--- a/src/tink/tcp/Connection.hx
+++ b/src/tink/tcp/Connection.hx
@@ -80,8 +80,10 @@ class Connection {
             if (to.secure)
               #if java
                 cast new java.net.SslSocket()
-              #else
+              #elseif (haxe_ver > 3.210)
                 cast new sys.ssl.Socket()
+              #else
+                throw 'Secure socket not available'
               #end
             else
               new Socket();

--- a/src/tink/tcp/Connection.hx
+++ b/src/tink/tcp/Connection.hx
@@ -70,7 +70,7 @@ class Connection {
   static public function tryEstablish(to:Endpoint, ?reader:Worker, ?writer:Worker):Surprise<Connection, Error> {
     var name = '[Connection to $to]';
     function fail(e:Dynamic) 
-      return Failure(Error.reporter(500, 'Failed to establish $name $e')(e));
+      return Failure(Error.reporter(500, 'Failed to establish $name')(e));
     #if (neko || cpp || java)
       reader = reader.ensure();
       writer = writer.ensure();

--- a/src/tink/tcp/Endpoint.hx
+++ b/src/tink/tcp/Endpoint.hx
@@ -3,13 +3,23 @@ package tink.tcp;
 private typedef EndpointData = {
   public var host(default, null):String;
   public var port(default, null):Int;
+  @:optional 
+  public var secure(default, null):Bool;
 }
 
-@:forward
+@:forward(host, port)
 abstract Endpoint(EndpointData) from EndpointData {
+  public var secure(get, never): Bool;
+  function get_secure()
+    return 
+      if (this.secure == null)
+        this.port == 443
+      else
+        this.secure;
+  
   @:from static function fromPort(port:Int):Endpoint
     return { port: port, host: '127.0.0.1' };
   
-  @:to function toString():String
+  @:to public function toString():String
     return '${this.host}:${this.port}';
 }

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -16,7 +16,7 @@ class RunTests {
 
         var runner = new buddy.SuitesRunner([
             new TestIssue3(),
-            new TestTlsConnection(),
+            #if (haxe_ver > 3.210) new TestSecureConnection(), #end
         ], reporter);
 
         runner.run().then(function (_) {

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -16,6 +16,7 @@ class RunTests {
 
         var runner = new buddy.SuitesRunner([
             new TestIssue3(),
+            new TestTlsConnection(),
         ], reporter);
 
         runner.run().then(function (_) {

--- a/tests/TestIssue3.hx
+++ b/tests/TestIssue3.hx
@@ -45,9 +45,9 @@ class TestIssue3 extends BuddySuite {
           case Failure(f):
             fail(f);
         });
-        //haxe.Timer.delay(function(){}, 2000);
       });
     });
   }
+  
 }
 

--- a/tests/TestSecureConnection.hx
+++ b/tests/TestSecureConnection.hx
@@ -10,19 +10,18 @@ using buddy.Should;
 using StringTools;
 using tink.CoreApi;
 
-class TestTlsConnection extends BuddySuite {
+class TestSecureConnection extends BuddySuite {
   
   public function new() {
-    describe("Tls connection", {
+    describe("Secure connection", {
       it("Read from a web server", function(done) {
         trace('trying to connect');
-        Connection.tryEstablish({host:'www.example.com', port:443}).handle(function(o) switch o {
+        Connection.tryEstablish({host:'encrypted.google.com', port:443}).handle(function(o) switch o {
           case Success(cnx):
             trace('connected');
-
             ([
                 "GET /",
-                "Host: www.example.com",
+                "Host: encrypted.google.com",
                 "Connection: Close",
              ].concat([""]).join("\r\n"):Source).pipeTo(cnx.sink).handle(function(o) switch o {
               case SinkFailed(e) | SourceFailed(e):
@@ -46,7 +45,6 @@ class TestTlsConnection extends BuddySuite {
           case Failure(f):
             fail(f);
         });
-        //haxe.Timer.delay(function(){}, 2000);
       });
     });
   }

--- a/tests/TestTlsConnection.hx
+++ b/tests/TestTlsConnection.hx
@@ -2,6 +2,7 @@ package;
 
 import haxe.io.*;
 import tink.io.*;
+import tink.io.StreamParser;
 import tink.tcp.*;
 import buddy.*;
 
@@ -9,13 +10,13 @@ using buddy.Should;
 using StringTools;
 using tink.CoreApi;
 
-class TestIssue3 extends BuddySuite {
+class TestTlsConnection extends BuddySuite {
   
   public function new() {
-    describe("Issue #3", {
+    describe("Tls connection", {
       it("Read from a web server", function(done) {
         trace('trying to connect');
-        Connection.tryEstablish({host:'www.example.com', port:80}).handle(function(o) switch o {
+        Connection.tryEstablish({host:'www.example.com', port:443}).handle(function(o) switch o {
           case Success(cnx):
             trace('connected');
 
@@ -50,4 +51,3 @@ class TestIssue3 extends BuddySuite {
     });
   }
 }
-


### PR DESCRIPTION
This adds ssl/tls to connections. Endpoint gets a `secure` property (optional, defaults to true only if port is 443). Test runs on latest haxe git for neko, java and node (could not get cpp to compile, but that seems unrelated). I'll have a look at server side ssl termination as well, but it'll probably take me more time.
