### PR TITLE
StdConnector

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.0",
     "command": "npm",
-    "args": ["run","travix","node"],
+    "args": ["run","--silent","travix","--","neko","-lib","tink_runloop","-D","concurrent"],
     "problemMatcher": {
         "owner": "haxe",
         "pattern": {

--- a/dev.hxml
+++ b/dev.hxml
@@ -1,6 +1,6 @@
 tests.hxml
 
--js bin/neko/tests.n
+-neko bin/neko/tests.n
 
 -lib travix
 -lib tink_tcp

--- a/haxe_libraries/tink_concurrent.hxml
+++ b/haxe_libraries/tink_concurrent.hxml
@@ -1,0 +1,5 @@
+# @install: lix --silent download haxelib:tink_concurrent#0.1.3 into tink_concurrent/0.1.3/haxelib
+-D tink_concurrent=0.1.3
+-cp ${HAXESHIM_LIBCACHE}/tink_concurrent/0.1.3/haxelib/src
+
+-lib tink_core

--- a/haxe_libraries/tink_io.hxml
+++ b/haxe_libraries/tink_io.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download https://github.com/haxetink/tink_io/archive/a138d8c79d374e81be91e5e0e7319cad0e4feab7.tar.gz into tink_io/0.0.0/github/a138d8c79d374e81be91e5e0e7319cad0e4feab7
+# @install: lix --silent download https://github.com/haxetink/tink_io/archive/0ec08c1feb249eb74987ea6c6c87e13a4528c63e.tar.gz into tink_io/0.0.0/github/0ec08c1feb249eb74987ea6c6c87e13a4528c63e
 -D tink_io=0.0.0
--cp ${HAXESHIM_LIBCACHE}/tink_io/0.0.0/github/a138d8c79d374e81be91e5e0e7319cad0e4feab7/src
+-cp ${HAXESHIM_LIBCACHE}/tink_io/0.0.0/github/0ec08c1feb249eb74987ea6c6c87e13a4528c63e/src
 
 -lib tink_chunk
 -lib tink_streams

--- a/haxe_libraries/tink_runloop.hxml
+++ b/haxe_libraries/tink_runloop.hxml
@@ -1,0 +1,6 @@
+# @install: lix --silent download https://github.com/haxetink/tink_runloop/archive/d481f8be2003e805ca92abc6812025bce2e577ca.tar.gz into tink_runloop/0.1.0/github/d481f8be2003e805ca92abc6812025bce2e577ca
+-D tink_runloop=0.1.0
+-cp ${HAXESHIM_LIBCACHE}/tink_runloop/0.1.0/github/d481f8be2003e805ca92abc6812025bce2e577ca/src
+--macro tink.runloop.Boot.boot()
+-lib tink_concurrent
+-lib tink_syntaxhub

--- a/haxe_libraries/tink_streams.hxml
+++ b/haxe_libraries/tink_streams.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download https://github.com/haxetink/tink_streams/archive/2881f7f62b37b78b31e3346bb10d6ea59732b739.tar.gz into tink_streams/0.1.0/github/2881f7f62b37b78b31e3346bb10d6ea59732b739
+# @install: lix --silent download https://github.com/haxetink/tink_streams/archive/21fd526ea23bc1e94c3339882b81f83fac113429.tar.gz into tink_streams/0.1.0/github/21fd526ea23bc1e94c3339882b81f83fac113429
 -D tink_streams=0.1.0
--cp ${HAXESHIM_LIBCACHE}/tink_streams/0.1.0/github/2881f7f62b37b78b31e3346bb10d6ea59732b739/src
+-cp ${HAXESHIM_LIBCACHE}/tink_streams/0.1.0/github/21fd526ea23bc1e94c3339882b81f83fac113429/src
 # temp for development, delete this file when pure branch merged
 -D pure
 -lib tink_core

--- a/src/tink/tcp/nodejs/NodejsAcceptor.hx
+++ b/src/tink/tcp/nodejs/NodejsAcceptor.hx
@@ -6,6 +6,7 @@ using tink.io.Source;
 using tink.io.Sink;
 using tink.CoreApi;
 
+@:require(nodejs)
 class NodejsAcceptor {
   static public var inst(default, null):NodejsAcceptor = new NodejsAcceptor();
   function new() {}

--- a/src/tink/tcp/nodejs/NodejsConnector.hx
+++ b/src/tink/tcp/nodejs/NodejsConnector.hx
@@ -4,6 +4,7 @@ using tink.io.Sink;
 using tink.io.Source;
 using tink.CoreApi;
 
+@:require(nodejs)
 class NodejsConnector {
   static public function connect(to:Endpoint, handler:Handler):Promise<Noise> 
     return Future.async(function (cb) {

--- a/src/tink/tcp/std/StdConnector.hx
+++ b/src/tink/tcp/std/StdConnector.hx
@@ -1,0 +1,67 @@
+package tink.tcp.std;
+
+import sys.net.*;
+import tink.io.Worker;
+import tink.streams.Stream.Handled;
+
+using tink.io.Sink;
+using tink.io.Source;
+using tink.CoreApi;
+
+class StdConnector {
+  static public function connect(to:Endpoint, handler:Handler, ?worker:Worker):Promise<Noise> {
+    return Future.async(function(cb) {
+      worker = worker.ensure();
+      
+      var socket = 
+        if(to.secure)
+          #if php new php.net.SslSocket();
+          #elseif java new java.net.SslSocket();
+          #elseif (!no_ssl && (hxssl || hl || cpp || (neko && !(macro || interp)))) new sys.ssl.Socket();
+          #else throw "Https is only supported with -lib hxssl";
+          #end
+        else
+          new Socket();
+          
+      var connected:Promise<Noise> = worker.work(function()
+        return try {
+          socket.connect(new Host(to.host), to.port);
+          #if !concurrent socket.setBlocking(false); #end
+          Success(Noise);
+        } catch(e:Dynamic) Failure(Error.withData('Cannot connect to $to', e))
+      );
+      
+      return connected.next(function(_) {
+        var peer = socket.peer();
+        var peer:Endpoint = {host: peer.host.toString(), port: peer.port};
+        var local = socket.host();
+        var local:Endpoint = {host: local.host.toString(), port: local.port};
+        var out = 'Outgoing stream of connection to $peer';
+        var source = Source.ofInput('Incoming stream of connection to $peer', socket.input);
+        var sink = Sink.ofOutput(out, socket.output);
+        var sourceClosed = Future.async(function(cb) source.chunked().forEach(function(_) return Resume).handle(function(_) cb(Noise)), true);
+        
+        return handler.handle({
+          stream: source,
+          from: peer,
+          to: local,
+          closed: sourceClosed,
+        }).map(function(outgoing) {
+          outgoing.stream.pipeTo(sink).handle(function (o) {
+            (
+              if (outgoing.allowHalfOpen) sourceClosed
+              else Future.sync(Noise)
+            ).handle(function () {
+              try socket.close() catch(e:Dynamic) {}
+              cb(switch o {
+                case SinkFailed(e, _): Failure(e);
+                case SinkEnded(_, { depleted: false }): Failure(new Error('$out closed before all data could be written'));
+                default: Success(Noise);
+              });
+            });
+          });
+        });
+      });
+    });
+  }
+}

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -7,7 +7,7 @@ class RunTests {
     public static function main() {
         Runner.run(TestBatch.make([
             new TestConnect(),
-            new TestAccept(),
+            // new TestAccept(),
         ])).handle(Runner.exit);
     }
 }

--- a/tests/TestConnect.hx
+++ b/tests/TestConnect.hx
@@ -3,8 +3,9 @@ package;
 import tink.io.*;
 import tink.io.PipeResult;
 import tink.tcp.*;
-import tink.tcp.nodejs.*;
 using tink.CoreApi;
+
+typedef Connector = #if nodejs tink.tcp.nodejs.NodejsConnector #else tink.tcp.std.StdConnector #end;
 
 @:asserts
 class TestConnect {
@@ -17,8 +18,7 @@ class TestConnect {
   #end
   @:variant('http' ('www.example.com', 80))
   public function connect(host:String, port:Int) {
-    
-    NodejsConnector.connect({host: host, port: port}, function(i:Incoming):Outgoing {
+    Connector.connect({host: host, port: port}, function(i:Incoming):Outgoing {
       i.stream.pipeTo(Sink.BLACKHOLE).handle(function(o) asserts.assert(o == AllWritten));
       return {
         stream: 'GET / HTTP/1.1\r\nHost: $host\r\nConnection: close\r\n\r\n',


### PR DESCRIPTION
Work in progress:

- Connector with `-D concurrent` seems ok
- Connector without `-D concurrent`: stack overflows because `InputSource` keeps reading from the socket and keeps emitting `Link(tink.Chunk.EMPTY, next(buf, offset));` because the socket is idle and  nothing can be read.

@back2dos any ideas? Feel free to push to the branch to save words :joy: